### PR TITLE
add FPStr type

### DIFF
--- a/src/footprints/__init__.py
+++ b/src/footprints/__init__.py
@@ -15,12 +15,13 @@ from bronx.patterns import observer
 
 from . import access, collectors, config, doc
 from . import priorities, proxies, reporting, util
-from .stdtypes import FPDict, FPList, FPRegex, FPSet, FPTuple
+from .stdtypes import FPDict, FPList, FPRegex, FPSet, FPStr, FPTuple
 
 assert FPDict
 assert FPList
 assert FPRegex
 assert FPSet
+assert FPStr
 assert FPTuple
 
 

--- a/src/footprints/stdtypes.py
+++ b/src/footprints/stdtypes.py
@@ -9,7 +9,7 @@ import re
 from bronx.syntax.decorators import secure_getattr
 
 #: Automatic export
-__all__ = ['FPDict', 'FPList', 'FPSet', 'FPTuple', 'FPRegex']
+__all__ = ['FPDict', 'FPList', 'FPSet', 'FPStr', 'FPTuple', 'FPRegex']
 
 
 class FPDict(dict):
@@ -45,6 +45,11 @@ class FPSet(set):
             return sorted(self)
         except TypeError:
             return list(self)
+
+
+class FPStr(str):
+    """A str type for FootPrints arguments (without expansion)."""
+    pass
 
 
 class FPTuple(tuple):

--- a/src/footprints/util.py
+++ b/src/footprints/util.py
@@ -211,6 +211,18 @@ def expand(desc):
     Explanation: The files currently in the working directory are matched using regular
     expressions. If the filename matches, some matching parts may be re-used to fill
     other keys in the dictionary.
+
+    Prevent Expansion::
+    Use the containers ``footprints.stdtypes.FPDict``, ``footprints.stdtypes.FPList``,
+    ``footprints.stdtypes.FPSet``, ``footprints.stdtypes.FPStr`` or 
+    ``footprints.stdtypes.FPTuple`` to avoid expansion.
+        >>> (expand({ 'test': 'alpha', 'niv2': footprints.stdtypes.FPList([ 'a', 'b', 'c' ])}) ==
+        ...  [{'test': 'alpha', 'niv2': footprints.stdtypes.FPList([ 'a', 'b', 'c' ]), 'index_expansion': 1}])
+        True
+
+        >>> (expand({'test': 'alpha', 'niv2': footprints.stdtypes.FPStr('x,y,z'}) ==
+        ...  [{'test': 'alpha', 'niv2': footprints.stdtypes.FPStr('x,y,z'), 'index_expansion': 1}])
+        True
     """
     ld = deque([desc, ])
     todo = True

--- a/tests/test_fp_util.py
+++ b/tests/test_fp_util.py
@@ -6,7 +6,7 @@ import tempfile
 
 from bronx.fancies import loggers
 
-from footprints import util, FPList
+from footprints import util, FPList, FPStr
 
 
 class Foo:
@@ -342,6 +342,12 @@ class utExpand(TestCase):
         self.assertListEqual(rv, [
             {'arg': 'hip', 'item': FPList([1, 2, 3]), 'index_expansion': 1},
             {'arg': 'hop', 'item': FPList([1, 2, 3]), 'index_expansion': 2},
+        ])
+
+        rv = util.expand(dict(arg=('hip', 'hop'), item=FPStr("a,b,c")))
+        self.assertListEqual(rv, [
+            {'arg': 'hip', 'item': FPStr("a,b,c"), 'index_expansion': 1},
+            {'arg': 'hop', 'item': FPStr("a,b,c"), 'index_expansion': 2},
         ])
 
 


### PR DESCRIPTION
This adds the class `FPStr` to prevent expansion of str.

For example:
```python
>>> expand({'test': 'alpha', 'niv2': footprints.stdtypes.FPStr('x,y,z'})
[{'test': 'alpha', 'niv2': footprints.stdtypes.FPStr('x,y,z'), 'index_expansion': 1}]
```

I have checked that this checks pyflakes and pycodestyle, I have added some tests and documentations.